### PR TITLE
Fix typo

### DIFF
--- a/mic.py
+++ b/mic.py
@@ -15,7 +15,7 @@ import numpy as np
 @click.option("--english", default=False, help="Whether to use English model",is_flag=True, type=bool)
 @click.option("--verbose", default=False, help="Whether to print verbose output", is_flag=True,type=bool)
 @click.option("--energy", default=300, help="Energy level for mic to detect", type=int)
-@click.option("--dynamic_energy", default=False,is_flag=True, help="Flag to enable dynamic engergy", type=bool)
+@click.option("--dynamic_energy", default=False,is_flag=True, help="Flag to enable dynamic energy", type=bool)
 @click.option("--pause", default=0.8, help="Pause time before entry ends", type=float)
 @click.option("--save_file",default=False, help="Flag to save file", is_flag=True,type=bool)
 def main(model, english,verbose, energy, pause,dynamic_energy,save_file):


### PR DESCRIPTION
Change the help message for the `--dinamic_energy` option from "Flag to enable dynamic engergy" to "Flag to enable dynamic energy"