### PR TITLE
Fixed "timeout" typo

### DIFF
--- a/whisper_mic/whisper_mic.py
+++ b/whisper_mic/whisper_mic.py
@@ -123,8 +123,8 @@ class WhisperMic:
             print(result)
                 
 
-    def listen(self,timout=3):
-        audio_data = self.get_all_audio(timout)
+    def listen(self,timeout=3):
+        audio_data = self.get_all_audio(timeout)
         self.transcribe(data=audio_data)
         while True:
             if not self.result_queue.empty():


### PR DESCRIPTION
Fixed spelling error of the word "timeout" in def listen at line 126 to facilitate the understanding of the library