### PR TITLE
fix/ keyboard interrupt for listen_loop

### DIFF
--- a/whisper_mic/whisper_mic.py
+++ b/whisper_mic/whisper_mic.py
@@ -121,7 +121,7 @@ class WhisperMic:
 
 
     def listen_loop(self, dictate: bool = False) -> None:
-        threading.Thread(target=self.transcribe_forever).start()
+        threading.Thread(target=self.transcribe_forever, daemon=True).start()
         while True:
             result = self.result_queue.get()
             if dictate:


### PR DESCRIPTION
just added daemon=True

By adding daemon=True, "transcribe_forever" process will exit gracefully with the main process.

[Mentioned Issue]
#53 