### PR TITLE
Save the transcription in a default file via the --save_file flag

### DIFF
--- a/whisper_mic/cli.py
+++ b/whisper_mic/cli.py
@@ -5,7 +5,7 @@ import torch
 import speech_recognition as sr
 from typing import Optional
 
-from whisper_mic.whisper_mic import WhisperMic
+from whisper_mic import WhisperMic
 
 @click.command()
 @click.option("--model", default="base", help="Model to use", type=click.Choice(["tiny","base", "small","medium","large","large-v2"]))

--- a/whisper_mic/cli.py
+++ b/whisper_mic/cli.py
@@ -26,10 +26,22 @@ def main(model: str, english: bool, verbose: bool, energy:  int, pause: float, d
         return
     mic = WhisperMic(model=model, english=english, verbose=verbose, energy=energy, pause=pause, dynamic_energy=dynamic_energy, save_file=save_file, device=device,mic_index=mic_index)
     if not loop:
-        result = mic.listen()
-        print("You said: " + result)
+        try:
+            result = mic.listen()
+            print("You said: " + result)
+        except KeyboardInterrupt:
+            print("Operation interrupted successfully")
+        finally:
+            if save_file:
+                mic.file.close()
     else:
-        mic.listen_loop(dictate=dictate,phrase_time_limit=2)
+        try:
+            mic.listen_loop(dictate=dictate,phrase_time_limit=2)
+        except KeyboardInterrupt:
+            print("Operation interrupted successfully")
+        finally:
+            if save_file:
+                mic.file.close()
 
 if __name__ == "__main__":
     main()

--- a/whisper_mic/whisper_mic.py
+++ b/whisper_mic/whisper_mic.py
@@ -146,7 +146,7 @@ class WhisperMic:
     def listen_loop(self, dictate: bool = False, phrase_time_limit=None) -> None:
         self.recorder.listen_in_background(self.source, self.__record_load, phrase_time_limit=phrase_time_limit)
         self.logger.info("Listening...")
-        threading.Thread(target=self.__transcribe_forever).start()
+        threading.Thread(target=self.__transcribe_forever, daemon=True).start()
         
         while True:
             result = self.result_queue.get()

--- a/whisper_mic/whisper_mic.py
+++ b/whisper_mic/whisper_mic.py
@@ -46,6 +46,9 @@ class WhisperMic:
 
         self.banned_results = [""," ","\n",None]
 
+        if save_file:
+            self.file = open("transcribed_text.txt", "w+", encoding="utf-8")
+
         self.__setup_mic(mic_index)
 
 
@@ -140,7 +143,8 @@ class WhisperMic:
                 self.result_queue.put_nowait(result)
 
         if self.save_file:
-            os.remove(audio_data)
+            # os.remove(audio_data)
+            self.file.write(predicted_text)
 
 
     def listen_loop(self, dictate: bool = False, phrase_time_limit=None) -> None:

--- a/whisper_mic/whisper_mic.py
+++ b/whisper_mic/whisper_mic.py
@@ -10,7 +10,7 @@ import tempfile
 import platform
 import pynput.keyboard
 
-from whisper_mic.utils import get_logger
+from utils import get_logger
 
 
 class WhisperMic:


### PR DESCRIPTION
The save_file flag did not seem to save the transcription in a file. I added basic code to handle the function. Also, I added the daemon parameter in the threading method as highlighted by szriru. 
If given the green signal, I can work on some enhancements like: 
 - Can add an overwrite option to either overwrite the contents in the file or just append to existing content.
 - Can ask user for the file or location to enter transcription.
Open to work on any other enhancements and fixes.

Issues: #53 and #56 
