### PR TITLE
Provide a method to obtain the results of `listen_loop`

### DIFF
--- a/whisper_mic/whisper_mic.py
+++ b/whisper_mic/whisper_mic.py
@@ -148,16 +148,20 @@ class WhisperMic:
 
 
     def listen_loop(self, dictate: bool = False, phrase_time_limit=None) -> None:
-        self.recorder.listen_in_background(self.source, self.__record_load, phrase_time_limit=phrase_time_limit)
-        self.logger.info("Listening...")
-        threading.Thread(target=self.__transcribe_forever, daemon=True).start()
-        
-        while True:
-            result = self.result_queue.get()
+        for result in self.listen_continuously(phrase_time_limit=phrase_time_limit):
             if dictate:
                 self.keyboard.type(result)
             else:
                 print(result)
+
+
+    def listen_continuously(self, phrase_time_limit=None):
+        self.recorder.listen_in_background(self.source, self.__record_load, phrase_time_limit=phrase_time_limit)
+        self.logger.info("Listening...")
+        threading.Thread(target=self.__transcribe_forever, daemon=True).start()
+
+        while True:
+            yield self.result_queue.get()
 
             
     def listen(self, timeout = None, phrase_time_limit=None):


### PR DESCRIPTION
Currently the `listen_loop` method simply prints the results to STDOUT. There is no way to access the string values. This PR moves the listening logic to `listen_continuously`, which yields the results one by one, and `listen_loop` can just call the new function. This is just a quick idea that came to my mind, there's probably a better way of doing it. But I need to read the values in my program to do stuff like terminating the process with a voice command, so I think this feature has its use cases.