### PR TITLE
Allow initializing WhisperMic without setting up the mic

### DIFF
--- a/whisper_mic/cli.py
+++ b/whisper_mic/cli.py
@@ -26,7 +26,7 @@ def main(model: str, english: bool, verbose: bool, energy:  int, pause: float, d
     if list_devices:
         print("Possible devices: ",sr.Microphone.list_microphone_names())
         return
-    mic = WhisperMic(model=model, english=english, verbose=verbose, energy=energy, pause=pause, dynamic_energy=dynamic_energy, save_file=save_file, device=device,mic_index=mic_index,implementation=("faster_whisper" if faster else "whisper"),hallucinate_threshold=hallucinate_threshold)
+    mic = WhisperMic(model=model, english=english, verbose=verbose, energy=energy, pause=pause, dynamic_energy=dynamic_energy, save_file=save_file, device=device,mic_index=mic_index,implementation=("faster_whisper" if faster else "whisper"),hallucinate_threshold=hallucinate_threshold,skip_mic_setup=False)
 
     if not loop:
         try:

--- a/whisper_mic/whisper_mic.py
+++ b/whisper_mic/whisper_mic.py
@@ -24,7 +24,7 @@ from whisper_mic.utils import get_logger
 # asound = cdll.LoadLibrary('libasound.so')
 # asound.snd_lib_error_set_handler(c_error_handler)
 class WhisperMic:
-    def __init__(self,model="base",device=("cuda" if torch.cuda.is_available() else "cpu"),english=False,verbose=False,energy=300,pause=2,dynamic_energy=False,save_file=False, model_root="~/.cache/whisper",mic_index=None,implementation="whisper",hallucinate_threshold=300):
+    def __init__(self,model="base",device=("cuda" if torch.cuda.is_available() else "cpu"),english=False,verbose=False,energy=300,pause=2,dynamic_energy=False,save_file=False, model_root="~/.cache/whisper",mic_index=None,implementation="whisper",hallucinate_threshold=300,skip_mic_setup=False):
 
         self.logger = get_logger("whisper_mic", "info")
         self.energy = energy
@@ -78,10 +78,11 @@ class WhisperMic:
         if save_file:
             self.file = open("transcribed_text.txt", "w+", encoding="utf-8")
 
-        self.__setup_mic(mic_index)
+        if not skip_mic_setup:
+            self.setup_mic(mic_index)
 
 
-    def __setup_mic(self, mic_index):
+    def setup_mic(self, mic_index):
         if mic_index is None:
             self.logger.info("No mic index provided, using default")
         self.source = sr.Microphone(sample_rate=16000, device_index=mic_index)


### PR DESCRIPTION
The current [__init__](https://github.com/mallorbc/whisper_mic/blob/8e700b75a152ee36db5fdd16af125cea8f9843a8/whisper_mic/whisper_mic.py#L27) method performs both model loading and mic setup. On macOS, it is forbidden to access the mic from a background thread. Because of this, we must initialize a `WhisperMic` object from the main thread. This means the UI will be frozen until the entire object is done initializing, which can take several minutes when first downloading a `large` model.

This PR allows initializing a `WhisperMic` object without mic setup, so that we can load model in the background.

- Renamed `__setup_mic` to `setup_mic`
- Added a flag called `skip_mic_setup` to the `__init__` method. When that flag is `True`, we skip calling `setup_mic` from `__init__`
- Set default value of `skip_mic_setup` to `False` to preserve current API
- Users can call `setup_mic()` later from the main thread when ready